### PR TITLE
Remove autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,5 @@
     ],
     "require": {
         "composer/installers": "~1.0"
-    },
-    "autoload": {
-        "files": ["wp-large-options.php"]
     }
 }


### PR DESCRIPTION
Autoloaded files should really not be executing code like this one does.
The file should only define functions to be used as an autoloader